### PR TITLE
[Refactor] formatingPrice 파일 안에 함수 구현 후 ReservationCard에 적용

### DIFF
--- a/src/components/accommodation/briefInfo/BriefInfo.tsx
+++ b/src/components/accommodation/briefInfo/BriefInfo.tsx
@@ -20,7 +20,7 @@ function BriefInfo() {
         />
         {accommodation.roomInfo.length > 0 && <RoomBedsInfo roomInfo={accommodation.roomInfo} />}
       </div>
-      <div className="flex justify-end w-4/12 pt-8">
+      <div className="flex justify-end w-4/12 pt-8 hidden md:inline">
         <ReservationCard />
       </div>
     </div>

--- a/src/components/accommodation/briefInfo/ReservationCard.tsx
+++ b/src/components/accommodation/briefInfo/ReservationCard.tsx
@@ -1,15 +1,16 @@
 'use client'
 
 import ReservationCardJson from '@data/ReservationCardJson.json'
+import { formatWithComma, totalPrice, priceWithDays } from '@/utils/formatingPrice'
 
 function ReservationCard() {
   const data = ReservationCardJson
 
   return (
     <>
-      <div className="w-[373px] shadow bg-white rounded-xl border border-solid border-neutral-200 p-6">
-        <div className="Text-neutral-800 text-[22px] font-[’SF Pro’] mb-6 font-bold text-left">
-          {`₩${data['fee'].toLocaleString()}`} <div className="inline text-base font-light">/박</div>
+      <div className=" shadow-lg bg-white rounded-xl border border-solid border-neutral-200 p-5">
+        <div className="Text-neutral-800 text-[22px] font-[’SF Pro’] mb-6 font-semibold text-left">
+          {formatWithComma(data.fee)} <div className="inline text-base font-normal">/박</div>
         </div>
         <div className="mb-3 text-left border border-solid rounded-lg border-neutral-400">
           <div className="flex flex-row">
@@ -28,17 +29,17 @@ function ReservationCard() {
           </div>
         </div>
         <button className="w-full py-4 my-1 text-white rounded-lg bg-rose-600"> 예약하기 </button>
-        <div className="text-zinc-600 text-sm font-normal font-['SF Pro'] my-3">
+        <div className="text-center text-zinc-600 text-sm font-normal font-['SF Pro'] my-3">
           예약 확정 전에는 요금이 청구되지 않습니다.
         </div>
-        <div className="flex flex-row justify-between my-8 ">
-          <div className="underline">{`₩${data['fee'].toLocaleString()} x ${data['days']}박`}</div>
-          <div>{`₩${(data['fee'] * data['days']).toLocaleString()}`}</div>
+        <div className="flex flex-row justify-between my-6 ">
+          <div className="underline">{priceWithDays(data.fee, data.days)}</div>
+          <div>{totalPrice(data.fee, data.days)}</div>
         </div>
         <hr />
-        <div className="flex flex-row justify-between mb-1 font-semibold mt-7">
+        <div className="flex flex-row justify-between mb-1 font-semibold mt-6">
           <div>총 합계</div>
-          <div>{`₩${(data['fee'] * data['days']).toLocaleString()}`}</div>
+          <div>{totalPrice(data.fee, data.days)}</div>
         </div>
       </div>
     </>

--- a/src/components/accommodation/detailBanner/DetailPageBanner.tsx
+++ b/src/components/accommodation/detailBanner/DetailPageBanner.tsx
@@ -14,9 +14,9 @@ function HeartButton() {
       }}>
       {/* {valid ? <UseHeartSvg className="mt-0.5 mr-2 size-5" /> : <UnUseHeartSvg className="mt-0.5 mr-2 size-5" />} */}
       {valid ? (
-        <Image alt={'useHeartIcon'} src={`/images/useHeartIcon.svg`} width={32} height={32} />
+        <Image alt={'useHeartIcon'} src={`/images/useHeartIcon.svg`} width={16} height={16} className="m-1" />
       ) : (
-        <Image alt={'unUseHeartIcon'} src={`/images/unUseHeartIcon.svg`} width={32} height={32} />
+        <Image alt={'unUseHeartIcon'} src={`/images/unUseHeartIcon.svg`} width={16} height={16} className="m-1" />
       )}
       <div className="underline">{valid ? '저장 목록' : '저장'}</div>
     </button>
@@ -26,7 +26,7 @@ function HeartButton() {
 function ShareButton() {
   return (
     <button className="flex p-2 mr-4 hover:bg-gray-200">
-      <Image alt={'shareIcon'} src={`/images/shareIcon.svg`} width={32} height={32} />
+      <Image alt={'shareIcon'} src={`/images/shareIcon.svg`} width={16} height={16} className="m-1" />
       <div className="underline">공유하기</div>
     </button>
   )
@@ -43,12 +43,11 @@ function DetailPageBanner() {
   const titleInfo = detailPageBanner.detailPage1.titleInfo
 
   return (
-    <div className="mx-20">
-      <div className="flex justify-between mb-3">
-        <div className="text-2xl font-bold">{titleInfo}</div>
+    <div>
+      <div className="flex justify-between mb-5">
+        <div className="text-2xl font-bold mt-6">{titleInfo}</div>
         <div className="flex items-end">
           <ShareButton />
-
           <HeartButton />
         </div>
       </div>

--- a/src/utils/formatingPrice.ts
+++ b/src/utils/formatingPrice.ts
@@ -1,0 +1,16 @@
+function formatWithComma(number: number): string {
+  // 3자리 마다 ,를 붙입니다. 1000 => ₩1,000
+  return `₩${number.toLocaleString()}`
+}
+
+function priceWithDays(price: number, days: number) {
+  // 가격 X n박 를 표시합니다
+  return `${formatWithComma(price)} x ${days}박`
+}
+
+function totalPrice(price: number, days: number) {
+  // 가격과 날을 곱한 총 합계를 표시합니다
+  return `${formatWithComma(price * days)}`
+}
+
+export { formatWithComma, totalPrice, priceWithDays }


### PR DESCRIPTION
# Pull Request

## 해결한 이슈의 타입을 선택해주세요.

- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 작업

## 해결한 이슈의 번호를 적어주세요. (# 이후에 숫자를 입력하면 이슈가 종료됩니다.)

close #16

## 반영 브랜치를 적어주세요.

branch : refactor/fe/formatingPrice

## 상세 내용을 적어주세요.

- utils 폴더를 추가하고 모두가 사용할 수 있는 함수 구현
  formatWithComma(number) => 맨앞에 ₩, 숫자3자리 마다 ,를 붙인 string을 반환합니다 ex) 1000 => ₩1,000
  priceWithDays(price, days) => ex) 1,000원 X 3박 
  totalPrice(price, days) => price와 days곱하고 format된 string 반환 ex) ₩3,000

- ReservationCard, DetailBanner의 CSS 수정