### PR TITLE
[Feat] 메인 페이지의 (숙소 정보가 담긴) 카드 무한 스크롤

### DIFF
--- a/src/app/apis/fetchMainPage/route.ts
+++ b/src/app/apis/fetchMainPage/route.ts
@@ -109,10 +109,9 @@ export async function GET(request: NextRequest) {
     const accommodations = data.accommodationInfo
 
     const filteredAccommodations = accommodations.filter(
-      acc => acc.accommodationId >= id && acc.accommodationId <= id + 40,
+      acc => acc.accommodationId >= id && acc.accommodationId <= id + 20,
     )
     const records = extractFieldsForList(filteredAccommodations, fields)
-
     return NextResponse.json(records, {
       status: 200,
       headers: {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import Category from '@/components/accommodation/categoryBundle/Category'
 import getRoomsList from '@/app/apis/fetchMainPage/getRoomsList'
 import Card from '@/components/card/card'
+import InfiniteScroll from '@/components/infiniteScroll/scroll'
 
 function RoomsItem({ accommodation }) {
   return (
@@ -41,6 +42,7 @@ export default async function Home() {
         {accommodations.map((accommodation, index) => (
           <RoomsItem key={`RoomsItem-${index}`} accommodation={accommodation} />
         ))}
+        <InfiniteScroll></InfiniteScroll>
       </div>
     </div>
   )

--- a/src/components/infiniteScroll/scroll.tsx
+++ b/src/components/infiniteScroll/scroll.tsx
@@ -4,7 +4,6 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import Card from '@/components/card/card'
 import Link from 'next/link'
 import getRoomList from '@/app/apis/fetchMainPage/getRoomsList'
-import Loader from '@/components/infiniteScroll/Loader'
 
 function RoomsItem({ accommodation }) {
   return (
@@ -26,29 +25,28 @@ function MainInfiniteScroll() {
   const [id, setId] = useState(21)
   const loaderRef = useRef(null)
 
-  const fields = [
-    //useMemo
-    'accommodationId',
-    'accommodationName',
-    'imageUrl',
-    'guestFavorite',
-    'rating',
-    'pricePerDay',
-  ]
-
   const fetchAccommodation = useCallback(async () => {
-    if (id >= 100) return
+    if (id > 340) return
     if (isLoading) return
+    const fields = [
+      'accommodationId',
+      'accommodationName',
+      'imageUrl',
+      'guestFavorite',
+      'rating',
+      'pricePerDay',
+    ]
 
     setIsLoading(true)
 
     const newAccommodation = await getRoomList(id, fields)
+
     setAccommodations(prev => [...prev, ...newAccommodation])
 
     setId(prevId => prevId + 20)
 
     setIsLoading(false)
-  }, [id, isLoading, fields])
+  }, [id, isLoading])
 
   useEffect(() => {
     const observer = new IntersectionObserver(
@@ -79,13 +77,13 @@ function MainInfiniteScroll() {
   }, [fetchAccommodation])
 
   return (
-    <div className='mt-8 grid w-full max-w-[1760px] grid-cols-1 gap-4 px-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5'>
+    <>
       {accommodations.map((accommodation, index) => (
         <RoomsItem key={`RoomsItem-${index}`} accommodation={accommodation} />
       ))}
       <div></div>
-      <div ref={loaderRef}>{isLoading && <Loader />}</div>
-    </div>
+      <div ref={loaderRef}></div>
+    </>
   )
 }
 

--- a/src/components/infiniteScroll/scroll.tsx
+++ b/src/components/infiniteScroll/scroll.tsx
@@ -21,13 +21,12 @@ function RoomsItem({ accommodation }) {
 
 function MainInfiniteScroll() {
   const [accommodations, setAccommodations] = useState([])
-  const [isLoading, setIsLoading] = useState(false)
   const [id, setId] = useState(21)
   const loaderRef = useRef(null)
 
   const fetchAccommodation = useCallback(async () => {
     if (id > 340) return
-    if (isLoading) return
+
     const fields = [
       'accommodationId',
       'accommodationName',
@@ -37,16 +36,12 @@ function MainInfiniteScroll() {
       'pricePerDay',
     ]
 
-    setIsLoading(true)
-
     const newAccommodation = await getRoomList(id, fields)
 
     setAccommodations(prev => [...prev, ...newAccommodation])
 
     setId(prevId => prevId + 20)
-
-    setIsLoading(false)
-  }, [id, isLoading])
+  }, [id])
 
   useEffect(() => {
     const observer = new IntersectionObserver(

--- a/src/components/infiniteScroll/scroll.tsx
+++ b/src/components/infiniteScroll/scroll.tsx
@@ -59,7 +59,6 @@ function MainInfiniteScroll() {
       },
       {
         threshold: 0.5,
-        rootMargin: '100px',
       },
     )
 

--- a/src/components/infiniteScroll/scroll.tsx
+++ b/src/components/infiniteScroll/scroll.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import Card from '@/components/card/card'
+import Link from 'next/link'
+import getRoomList from '@/app/apis/fetchMainPage/getRoomsList'
+
+function RoomsItem({ accommodation }) {
+  return (
+    <Link href={`/rooms/${accommodation.accommodationId}`}>
+      <Card
+        accommodationName={accommodation.accommodationName}
+        imageUrl={accommodation.imageUrl}
+        pricePerDay={accommodation.pricePerDay}
+        rating={accommodation.rating}
+        guestFavorite={accommodation.guestFavorite}
+      />
+    </Link>
+  )
+}
+
+function MainInfiniteScroll() {
+  const [accommodations, setAccommodations] = useState([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [id, setId] = useState(41)
+  const loaderRef = useRef(null)
+  const fields = [
+    'accommodationId',
+    'accommodationName',
+    'imageUrl',
+    'guestFavorite',
+    'rating',
+    'pricePerDay',
+  ]
+  const fetchAccommodation = useCallback(async () => {
+    if (isLoading) return
+
+    setIsLoading(true)
+
+    setAccommodations(await getRoomList(id, fields))
+
+    setId(prevId => prevId + 1)
+
+    setIsLoading(false)
+  }, [id, isLoading])
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(entries => {
+      const target = entries[0]
+      if (target.isIntersecting) {
+        fetchAccommodation()
+      }
+    })
+
+    if (loaderRef.current) {
+      observer.observe(loaderRef.current)
+    }
+
+    return () => {
+      if (loaderRef.current) {
+        observer.unobserve(loaderRef.current)
+      }
+    }
+  }, [fetchAccommodation])
+
+  return (
+    <div className='container'>
+      {accommodations.map((accommodation, index) => (
+        <RoomsItem key={`RoomsItem-${index}`} accommodation={accommodation} />
+      ))}
+
+      <div ref={loaderRef}></div>
+    </div>
+  )
+}
+
+export default MainInfiniteScroll

--- a/src/components/infiniteScroll/scroll.tsx
+++ b/src/components/infiniteScroll/scroll.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import Card from '@/components/card/card'
 import Link from 'next/link'
 import getRoomList from '@/app/apis/fetchMainPage/getRoomsList'
+import Loader from '@/components/infiniteScroll/Loader'
 
 function RoomsItem({ accommodation }) {
   return (
@@ -22,9 +23,11 @@ function RoomsItem({ accommodation }) {
 function MainInfiniteScroll() {
   const [accommodations, setAccommodations] = useState([])
   const [isLoading, setIsLoading] = useState(false)
-  const [id, setId] = useState(41)
+  const [id, setId] = useState(21)
   const loaderRef = useRef(null)
+
   const fields = [
+    //useMemo
     'accommodationId',
     'accommodationName',
     'imageUrl',
@@ -32,44 +35,56 @@ function MainInfiniteScroll() {
     'rating',
     'pricePerDay',
   ]
+
   const fetchAccommodation = useCallback(async () => {
+    if (id >= 100) return
     if (isLoading) return
 
     setIsLoading(true)
 
-    setAccommodations(await getRoomList(id, fields))
+    const newAccommodation = await getRoomList(id, fields)
+    setAccommodations(prev => [...prev, ...newAccommodation])
 
-    setId(prevId => prevId + 1)
+    setId(prevId => prevId + 20)
 
     setIsLoading(false)
-  }, [id, isLoading])
+  }, [id, isLoading, fields])
 
   useEffect(() => {
-    const observer = new IntersectionObserver(entries => {
-      const target = entries[0]
-      if (target.isIntersecting) {
-        fetchAccommodation()
-      }
-    })
+    const observer = new IntersectionObserver(
+      entries => {
+        const target = entries[0]
 
-    if (loaderRef.current) {
-      observer.observe(loaderRef.current)
+        if (target.isIntersecting) {
+          fetchAccommodation()
+        }
+      },
+      {
+        threshold: 0.5,
+        rootMargin: '100px',
+      },
+    )
+
+    const currentLoader = loaderRef.current
+
+    if (currentLoader) {
+      observer.observe(currentLoader)
     }
 
     return () => {
-      if (loaderRef.current) {
-        observer.unobserve(loaderRef.current)
+      if (currentLoader) {
+        observer.unobserve(currentLoader)
       }
     }
   }, [fetchAccommodation])
 
   return (
-    <div className='container'>
+    <div className='mt-8 grid w-full max-w-[1760px] grid-cols-1 gap-4 px-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5'>
       {accommodations.map((accommodation, index) => (
         <RoomsItem key={`RoomsItem-${index}`} accommodation={accommodation} />
       ))}
-
-      <div ref={loaderRef}></div>
+      <div></div>
+      <div ref={loaderRef}>{isLoading && <Loader />}</div>
     </div>
   )
 }


### PR DESCRIPTION
# Pull Request

## 해결한 이슈의 타입을 선택해주세요.

- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 작업

## 해결한 이슈의 번호를 적어주세요. (# 이후에 숫자를 입력하면 이슈가 종료됩니다.)

close #42 

## 반영 브랜치를 적어주세요.

branch : feature/fe/main-scroll

## 상세 내용을 적어주세요.

1. 메인 페이지에서 스크롤을 가장 하단으로 내렸을 때 20개의 숙소 카드를 추가로 불러옵니다.
2. Observer를 사용해서 구현했습니다.
3. 창의님이 의견 주셨던, 로딩 시간의 문제로 초기에는 SSR로 숙소 카드를 가져오고, 이후 스크롤을 내렸을 때부터는 CSR로 로드합니다.
4. 현재는 숙소 ID가 340(340이 전부임)이 되었을 때 fetch 해오는 것을 return하도록 하드코딩 해뒀습니다. 나중에 Spring에서 pagination으로 가져올 것으로 예상되어 수정하지 않았습니다. 
5. 